### PR TITLE
Update tk_event (link rot)

### DIFF
--- a/docs/events/index.html
+++ b/docs/events/index.html
@@ -388,7 +388,7 @@ widget.when_clicked = do_this
 <p>The event data returned has:</p>
 <ul>
 <li><code>widget</code> - the guizero widget which raised the event</li>
-<li><code>tk_event</code> - the <a href="http://effbot.org/tkinterbook/tkinter-events-and-bindings.htm">tkinter event object</a></li>
+<li><code>tk_event</code> - the <a href="https://dafarry.github.io/tkinterbook/tkinter-events-and-bindings.htm">tkinter event object</a></li>
 <li><code>key</code> - the key which raised the event</li>
 <li><code>x</code> - the mouse's x position relative to the widget when the event occurred</li>
 <li><code>y</code> - the mouse's y position relative to the widget when the event occurred</li>


### PR DESCRIPTION
Broken link: http://effbot.org/tkinterbook/tkinter-events-and-bindings.htm (domain name sold), so relinked to 'salvaged' page at https://dafarry.github.io/tkinterbook/tkinter-events-and-bindings.htm